### PR TITLE
Look for custom keys in top-level package.json

### DIFF
--- a/any-promise.js
+++ b/any-promise.js
@@ -16,6 +16,26 @@ module.exports = (function(){
       "when",
       "q"];
   }
+  
+  // on Node.js:
+  // Look for a custom "any-promise" key in the top-level package.json file
+  
+  if (typeof require !== 'undefined' && PROMISE_IMPL === undef) {
+    var packageJSONEntry = null;
+    try {
+      var appRoot = require('app-root-path') + '';
+      var packageJSONEntry = require('pkg-conf').sync('any-promise', {
+        cwd: appRoot
+      });
+    } catch(e) {
+      console.error(e);
+    }
+    
+    if (packageJSONEntry && packageJSONEntry.preference) {
+      libs = [packageJSONEntry.preference];
+    }
+  }
+  
   var i = 0, len = libs.length, lib;
   for(; i < len; i++){
     try {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "url": "https://github.com/kevinbeaty/any-promise/issues"
   },
   "homepage": "http://github.com/kevinbeaty/any-promise",
-  "dependencies": {},
+  "dependencies": {
+    "app-root-path": "^1.0.0",
+    "pkg-conf": "^1.1.1"
+  },
   "devDependencies": {
     "promise": "~7.1.1",
     "es6-promise": "~3.0.2",


### PR DESCRIPTION
This implements one of the approaches discussed in #1, namely looking for the top-level `package.json` file by walking up the dependency tree and looking for:

 * A custom `"any-promise"` key in the `package.json` file, or
 * An explicitly installed Promise dependency

and using the results to determine which `Promise` library to load.

This is not necessarily a suggestion for the final implementation, but rather a starting point for discussion, I guess. :smile: