### PR TITLE
Remove PROMISE_IMPL in favor of register.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,4 @@ env:
   - ANY_PROMISE=bluebird
   - ANY_PROMISE=rsvp
   - ANY_PROMISE=when
-  - PROMISE_IMPL=
-  - PROMISE_IMPL=es6-promise
-  - PROMISE_IMPL=bluebird
   # - ANY_PROMISE=q

--- a/register.js
+++ b/register.js
@@ -10,17 +10,16 @@ var registered = null
  * following priority:
  *
  * 1. Previous registration
- * 2. Implementation specified by PROMISE_IMPL
- * 3. global.Promise if node.js version >= 0.12
- * 4. Auto detected promise based on first sucessful require of
+ * 2. global.Promise if node.js version >= 0.12
+ * 3. Auto detected promise based on first sucessful require of
  *    known promise libraries. Note this is a last resort, as the
  *    loaded library is non-deterministic. node.js >= 0.12 will
  *    always use global.Promise over this priority list.
- * 5. Throws error.
+ * 4. Throws error.
  */
 module.exports = register
 function register(implementation){
-  implementation = implementation || process.env.PROMISE_IMPL || null
+  implementation = implementation || null
 
   if(registered !== null
       && implementation !== null

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,18 +4,14 @@ if(process.env.ANY_PROMISE){
   // should load registration regardless
   expectedImpl = process.env.ANY_PROMISE
   require('../register')(expectedImpl)
-} else if(process.env.PROMISE_IMPL){
-  // should load implementation specified by env variable
-  expectedImpl = process.env.PROMISE_IMPL
 } else {
   var version = (/v(\d+)\.(\d+)\.(\d+)/).exec(process.version)
   if(version && +version[1] == 0 && +version[2] < 12){
-    // Node <0.12 should load first successful require in
-    // priority list if not registered and no PROMISE_IMPL
+    // Node < 0.12 should load first successful require in
+    // priority list if not registered
     expectedImpl = 'es6-promise'
   } else {
-    // Node >= 0.12 should load global.Promise
-    // if not registered and no PROMISE_IMPL
+    // Node >= 0.12 should load global.Promise if not registered
     expectedImpl = 'global.Promise'
   }
 }


### PR DESCRIPTION
Removes the PROMISE_IMPL env registration in favor of `require('any-promise/register')`.  PROMISE_IMPL was a holdover from version 0.1.0 and primarily left for transition from previous
installations in 0.2.0.  Removing now in prep for version 1.0.0.