### PR TITLE
Global Registration #8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 sudo: false
 node_js:
   - "0.10"
-  - "0.11"
   - "0.12"
-  - "4.0"
-  - "5.0"
+  - "iojs-v1"
+  - "iojs-v2"
+  - "iojs-v3"
+  - "4"
+  - "5"
 env:
   - ANY_PROMISE=
   - ANY_PROMISE=es6-promise

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ You must register your preference before any call to `require('any-promise')` (b
 
 Registration is not required for Node.js version >= 0.12 as a native `Promise` implementation is included. If no preference is registered, the global `Promise` will be used.
 
-To ensure registration works correctly across all dependencies, it is necessary that only one `any-promise` package is installed in the dependency tree. To ensure this, you should use [`npm dedupe`](https://docs.npmjs.com/cli/dedupe) or manually remove any `any-promise` packages not at the top level of your application dependency tree.
-
 #### Example:
 
 Assuming `when` is the desired Promise implementation:

--- a/register.js
+++ b/register.js
@@ -1,5 +1,8 @@
 "use strict"
-var registered = null
+    // global key for user preferred registration
+var REGISTRATION_KEY = '@@any-promise/REGISTRATION',
+    // Prior registration (preferred or detected)
+    registered = null
 
 /**
  * Registers the given implementation.  An implementation must
@@ -21,6 +24,11 @@ module.exports = register
 function register(implementation){
   implementation = implementation || null
 
+  // load any previous global registration
+  if(registered === null){
+    registered = global[REGISTRATION_KEY] || null
+  }
+
   if(registered !== null
       && implementation !== null
       && registered.implementation !== implementation){
@@ -35,6 +43,8 @@ function register(implementation){
     if(implementation !== null){
       // require implementation if we haven't done yet and is specified
       registered = loadImplementation(implementation)
+      // register preference globally in case multiple installations
+      global[REGISTRATION_KEY] = registered
     } else if(shouldPreferGlobalPromise()){
       // if no implementation or env specified use global.Promise
       registered = loadGlobal()
@@ -87,7 +97,7 @@ function shouldPreferGlobalPromise(){
  * Otherwise uses require
  */
 function loadImplementation(implementation){
-  if(implementation == 'global.Promise'){
+  if(implementation === 'global.Promise'){
     return loadGlobal()
   }
 


### PR DESCRIPTION
- Store user registration in a global variable and use if previously set to allow registration to work across multiple installations of any-promise.