### PR TITLE
Version 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ node_js:
   - "iojs-v3"
   - "4"
   - "5"
+  - "6"
 env:
   - BROWSER=1
+  - BROWSER_LOCAL=1
+  - BROWSER_POLYFILL=1
   - ANY_PROMISE=
   - ANY_PROMISE=es6-promise
   - ANY_PROMISE=promise

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2014 Kevin Beaty
+Copyright (C) 2014-2016 Kevin Beaty
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	rm -rf build
 
 test: | node_modules
-	`npm bin`/mocha test/index.js
+	npm test
 
 node_modules:
 	npm install
@@ -22,7 +22,7 @@ node_modules:
 
 js: $(JS_TARGET) $(JS_TARGET:.js=.min.js)
 
-$(JS_TARGET): $(PROJECT).js | build
+$(JS_TARGET): index.js register-shim.js register.js loader.js | build
 	`npm bin`/browserify $< > $@
 
 build:

--- a/README.md
+++ b/README.md
@@ -4,60 +4,11 @@
 
 Let your library support any ES 2015 (ES6) compatible `Promise` and leave the choice to application authors. The application can register its preferred `Promise` implementation and it will be exported when requiring `any-promise` from library code.
 
-If no preference is registered, defaults to the global `Promise` for newer Node.js versions. The browser version will always export the global `Promise`, so polyfill as necessary.
-
-### Application Registration
-
-As an application author, you can optionally register a preferred `Promise` implementation on application startup (before any call to `require('any-promise')`:
-
-```javascript
-require('any-promise/register')('bluebird')
-// -or- require('any-promise/register')('es6-promise')
-// -or- require('any-promise/register')('native-promise-only')
-// -or- require('any-promise/register')('rsvp')
-// -or- require('any-promise/register')('when')
-// -or- require('any-promise/register')('q')
-// -or- require('any-promise/register')('any other ES6 compatible library')
-```
-
-You must register your preference before any call to `require('any-promise')` (by you or required packages), and only one implementation can be registered. Typically, this registration would occur at the top of the application entry point.
-
-Registration is not required for Node.js version >= 0.12 as a native `Promise` implementation is included. If no preference is registered, the global `Promise` will be used.
-
-#### Example:
-
-Assuming `when` is the desired Promise implementation:
-
-```bash
-# Install preferred promise library
-$ npm install when
-# Install any-promise to allow registration
-$ npm install any-promise
-# Install any libraries you would like to use depending on any-promise
-$ npm install mz
-```
-Register your preference in the application entry point before any other `require` of packages that load `any-promise`:
-
-```javascript
-// top of application index.js or other entry point
-require('any-promise/register')('when')
-```
-
-Now that the implementation is registered, you can use any package depending on `any-promise`:
-
-```javascript
-var fsp = require('mz/fs') // mz/fs will use registered `when` promises
-var Promise = require('any-promise')  // the registered `when.Promise`
-```
-
-It is safe to call `register` multiple times, but it must always be with the same implementation.
-
-Again, registration is not required. It should only be called by the application user if overriding the default implementation is desired.
-
+If no preference is registered, defaults to the global `Promise` for newer Node.js versions. The browser version defaults to the window `Promise`, so polyfill or register as necessary.
 
 ### Library Usage
 
-Libraries using `any-promise` should only use [documented](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) functions as there is no guarantee which implementation will be chosen by the end user.
+To use any `Promise` constructor, simply require it:
 
 ```javascript
 var Promise = require('any-promise');
@@ -77,9 +28,81 @@ return new Promise(function(resolve, reject){
 
 ```
 
-Libraries should never call `register`, only the application user should call if desired.
+Libraries using `any-promise` should only use [documented](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) functions as there is no guarantee which implementation will be chosen by the application author.  Libraries should never call `register`, only the application user should call if desired.
+
+### Optional Application Registration
+
+As an application author, you can *optionally* register a preferred `Promise` implementation on application startup (before any call to `require('any-promise')`:
+
+```javascript
+require('any-promise/register')('bluebird')
+// -or- require('any-promise/register')('es6-promise')
+// -or- require('any-promise/register')('native-promise-only')
+// -or- require('any-promise/register')('rsvp')
+// -or- require('any-promise/register')('when')
+// -or- require('any-promise/register')('q')
+// -or- require('any-promise/register')('any other ES6 compatible library')
+```
+You must register your preference before any call to `require('any-promise')` (by you or required packages), and only one implementation can be registered. Typically, this registration would occur at the top of the application entry point.
+
+Registration is not required for Node.js version >= 0.12 as a native `Promise` implementation is included. If no preference is registered, the global `Promise` will be used.
+
+
+#### Advanced Registration
+
+To use the browser version, you should either install a polyfill or explicitly register the `Promise` constructor:
+
+```javascript
+require('any-promise/register')('bluebird', {Promise: require('bluebird')})
+```
+
+This could also be used for registering a custom `Promise` implementation or subclass.
+
+Your preference will be registered globally, allowing a single registration even if multiple versions of `any-promise` are installed in the NPM dependency tree or are using multiple bundled JavaScript files in the browser. You can bypass this global registration in options:
+
+
+```javascript
+require('../register')('es6-promise', {Promise: require('es6-promise').Promise, global: false})
+```
+
+#### Example:
+
+Assuming `when` is the desired Promise implementation:
+
+```bash
+# Install preferred promise library
+$ npm install when
+# Install any-promise to allow registration
+$ npm install any-promise
+# Install any libraries you would like to use depending on any-promise
+$ npm install mz
+```
+Register your preference in the application entry point before any other `require` of packages that load `any-promise`:
+
+```javascript
+// top of application index.js or other entry point
+require('any-promise/register')('when')
+
+// -or- Equivalent to above in Node.js, but browser version needs polyfill or explicit registration
+require('any-promise/register')('when', {Promise: require('when').Promise})
+```
+
+Now that the implementation is registered, you can use any package depending on `any-promise`:
+
+
+```javascript
+var fsp = require('mz/fs') // mz/fs will use registered `when` promises
+var Promise = require('any-promise')  // the registered `when.Promise`
+```
+
+It is safe to call `register` multiple times, but it must always be with the same implementation.
+
+Again, registration is not required. It should only be called by the application user if overriding the default implementation is desired.
+
+### Advanced Library Usage
 
 If your library needs to branch code based on the registered implementation, you can retrieve it using `var impl = require('any-promise/implementation')`, where `impl` will be the package name (`"bluebird"`, `"when"`, etc.) if registered, `"global.Promise"` if using the global version on Node.js, or `"window.Promise"` if using the browser version. You should always include a default case, as there is no guarantee what package may be registered.
+
 
 ### Support for old Node.js versions
 

--- a/loader.js
+++ b/loader.js
@@ -12,6 +12,8 @@ var REGISTRATION_KEY = '@@any-promise/REGISTRATION',
  * If called with no arguments, will return registration in
  * following priority:
  *
+ * For Node.js:
+ *
  * 1. Previous registration
  * 2. global.Promise if node.js version >= 0.12
  * 3. Auto detected promise based on first sucessful require of
@@ -19,6 +21,18 @@ var REGISTRATION_KEY = '@@any-promise/REGISTRATION',
  *    loaded library is non-deterministic. node.js >= 0.12 will
  *    always use global.Promise over this priority list.
  * 4. Throws error.
+ *
+ * For Browser:
+ *
+ * 1. Previous registration
+ * 2. window.Promise
+ * 3. Throws error.
+ *
+ * Options:
+ *
+ * Promise: Desired Promise constructor
+ * global: Boolean - Should the registration be cached in a global variable to
+ * allow cross dependency/bundle registration?  (default true)
  */
 module.exports = function(root, loadImplementation){
   return function register(implementation, opts){
@@ -57,14 +71,6 @@ module.exports = function(root, loadImplementation){
         // register preference globally in case multiple installations
         root[REGISTRATION_KEY] = registered
       }
-    }
-
-    if(registered === null){
-      throw new Error('Cannot find any-promise implementation nor'+
-        ' global.Promise. You must install polyfill or call'+
-        ' require("any-promise/register") with your preferred'+
-        ' implementation, e.g. require("any-promise/register")("bluebird")'+
-        ' on application load prior to any require("any-promise").')
     }
 
     return registered

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "any-promise",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Resolve any installed ES6 compatible promise",
   "main": "index.js",
   "browser": {
     "./register.js": "./register-shim.js"
   },
   "scripts": {
-    "test": "make test"
+    "test": "mocha test/index.js"
   },
   "repository": {
     "type": "git",

--- a/register-shim.js
+++ b/register-shim.js
@@ -1,7 +1,16 @@
 "use strict";
-module.exports = require('./lib')(window, loadImplementation)
+module.exports = require('./loader')(window, loadImplementation)
 
+/**
+ * Browser specific loadImplementation.  Always uses `window.Promise`
+ *
+ * To register a custom implementation, must register with `Promise` option.
+ */
 function loadImplementation(){
+  if(typeof window.Promise === 'undefined'){
+    throw new Error("any-promise browser requires a polyfill or explicit registration"+
+      " e.g: require('any-promise/register')('bluebird', {Promise: require('bluebird')})")
+  }
   return {
     Promise: window.Promise,
     implementation: 'window.Promise'

--- a/register.js
+++ b/register.js
@@ -1,68 +1,66 @@
 "use strict"
-module.exports = require('./lib')(global, loadImplementation);
+module.exports = require('./loader')(global, loadImplementation);
 
 /**
+ * Node.js version of loadImplementation.
+ *
  * Requires the given implementation and returns the registration
  * containing {Promise, implementation}
  *
- * The returned Promise will be the Promise property if
- * defined, otherwise it will return the library itself.
- *
- * If implementation is global.Promise, calls loadGlobal
+ * If implementation is undefined or global.Promise, loads it
  * Otherwise uses require
  */
 function loadImplementation(implementation){
-  if(!implementation){
-    if(shouldPreferGlobalPromise()){
-      // if no implementation or env specified use global.Promise
-      return loadGlobal()
-    } else {
-      // try to auto detect implementation. This is non-deterministic
-      // and should prefer other branches, but this is our last chance
-      // to load something without throwing error
-      return tryAutoDetect()
-    }
-  } else {
-    if(implementation === 'global.Promise'){
-      return loadGlobal()
-    }
+  var impl = null
 
+  if(shouldPreferGlobalPromise(implementation)){
+    // if no implementation or env specified use global.Promise
+    impl = {
+      Promise: global.Promise,
+      implementation: 'global.Promise'
+    }
+  } else if(implementation){
+    // if implementation specified, require it
     var lib = require(implementation)
-    return {
+    impl = {
       Promise: lib.Promise || lib,
       implementation: implementation
     }
+  } else {
+    // try to auto detect implementation. This is non-deterministic
+    // and should prefer other branches, but this is our last chance
+    // to load something without throwing error
+    impl = tryAutoDetect()
   }
+
+  if(impl === null){
+    throw new Error('Cannot find any-promise implementation nor'+
+      ' global.Promise. You must install polyfill or call'+
+      ' require("any-promise/register") with your preferred'+
+      ' implementation, e.g. require("any-promise/register")("bluebird")'+
+      ' on application load prior to any require("any-promise").')
+  }
+
+  return impl
 }
 
 /**
  * Determines if the global.Promise should be preferred if an implementation
  * has not been registered.
  */
-function shouldPreferGlobalPromise(){
-  // Versions < 0.11 did not have global Promise
-  if(typeof global.Promise !== 'undefined'){
-    // do not use for version < 0.12 as version 0.11 contained buggy versions
+function shouldPreferGlobalPromise(implementation){
+  if(implementation){
+    return implementation === 'global.Promise'
+  } else if(typeof global.Promise !== 'undefined'){
+    // Load global promise if implementation not specified
+    // Versions < 0.11 did not have global Promise
+    // Do not use for version < 0.12 as version 0.11 contained buggy versions
     var version = (/v(\d+)\.(\d+)\.(\d+)/).exec(process.version)
-    if(version && +version[1] == 0 && +version[2] < 12){
-      return false
-    }
-    return true
+    return !(version && +version[1] == 0 && +version[2] < 12)
   }
-  return false
-}
 
-/**
- * Loads global.Promise if defined, otherwise returns null
- */
-function loadGlobal(){
-  if(typeof global.Promise !== 'undefined'){
-    return {
-      Promise: global.Promise,
-      implementation: 'global.Promise'
-    }
-  }
-  return null
+  // do not have global.Promise or another implementation was specified
+  return false
 }
 
 /**

--- a/test/browser-local.js
+++ b/test/browser-local.js
@@ -1,0 +1,10 @@
+'use strict';
+var REGISTRATION_KEY = '@@any-promise/REGISTRATION'
+
+require('../register')('my-when', {Promise: require('when').Promise, global: false})
+
+if(typeof window[REGISTRATION_KEY] !== 'undefined'){
+  throw new Error('Expecting local registration')
+}
+
+require('./tests')

--- a/test/browser-polyfill.js
+++ b/test/browser-polyfill.js
@@ -1,10 +1,9 @@
 'use strict';
 
 var REGISTRATION_KEY = '@@any-promise/REGISTRATION'
+require('es6-promise').polyfill()
 
-require('../register')('bluebird', {Promise: require('bluebird')})
-
-if(window[REGISTRATION_KEY].implementation !== 'bluebird'){
+if(window[REGISTRATION_KEY].implementation !== 'window.Promise'){
   throw new Error('Expecting global registration')
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,25 +1,35 @@
 'use strict';
 
-var spawn = require('child_process').spawn;
-var expectedImpl;
+var REGISTRATION_KEY = '@@any-promise/REGISTRATION',
+    spawn = require('child_process').spawn,
+    expectedImpl,
+    globalRegistration = true
 
 if(process.env.BROWSER){
-  it('Promises/A+ tests in browser', function (done) {
-    this.timeout(30000)
-    var zuul = spawn('zuul', ['--phantom', '--ui', 'mocha-bdd', '--', 'test/browser.js'], {stdio: 'inherit'});
-    zuul.on('close', function (code) {
-      if(code !== 0){
-        throw new Error('Running tests in browser did not exit successfully.');
-      }
-      done();
-    });
-  });
+  it('Promises/A+ tests in browser', function(done){
+    this.timeout(60000)
+    zuul('test-browser.js', done)
+  })
+} else if(process.env.BROWSER_LOCAL){
+  it('Promises/A+ tests in browser with local registration', function(done){
+    this.timeout(60000)
+    zuul('test-browser-local.js', done)
+  })
+} else if(process.env.BROWSER_POLYFILL){
+  it('Promises/A+ tests in browser with polyfill', function(done){
+    this.timeout(60000)
+    zuul('test-browser-polyfill.js', done)
+  })
 } else {
   if(process.env.ANY_PROMISE){
     // should load registration regardless
     expectedImpl = process.env.ANY_PROMISE
     require('../register')(expectedImpl)
   } else {
+    if(process.env.NODE_LOCAL){
+      require('../register')(expectedImpl, {global: false})
+      globalRegistration = false
+    }
     var version = (/v(\d+)\.(\d+)\.(\d+)/).exec(process.version)
     if(version && +version[1] == 0 && +version[2] < 12){
       // Node < 0.12 should load first successful require in
@@ -35,6 +45,25 @@ if(process.env.BROWSER){
   if(impl !== expectedImpl){
     throw new Error('Expecting '+expectedImpl+' got '+impl)
   }
-  console.log('Starting tests with implementation '+impl);
-  require('./tests');
+
+  if(globalRegistration && impl !== global[REGISTRATION_KEY].implementation){
+    throw new Error('Expecting global registration '+expectedImpl)
+  }
+
+  if(!globalRegistration && typeof global[REGISTRATION_KEY] !== 'undefined'){
+    throw new Error('Expecting local registration')
+  }
+
+  console.log('Starting tests with implementation '+impl)
+  require('./tests')
+}
+
+function zuul(file, done){
+  var zuul = spawn('zuul', ['--phantom', '--ui', 'mocha-bdd', '--', 'test/browser.js'], {stdio: 'inherit'})
+  zuul.on('close', function (code) {
+    if(code !== 0){
+      throw new Error('Running tests in browser did not exit successfully.')
+    }
+    done()
+  })
 }


### PR DESCRIPTION
- Add tests for local registration and browser polyfill
- Test for expected global registration
- Update documentation
- Ensure `window.Promise` is defined in browser version.
- Use `npm test` in Makefile so `zuul` bin is available
- Bump version
- Add Node.js v6 to Travis-CI